### PR TITLE
.

### DIFF
--- a/Daemon/Conf.cpp
+++ b/Daemon/Conf.cpp
@@ -46,6 +46,7 @@ m_callsign(),
 m_text(),
 m_bleep(true),
 m_daemon(false),
+m_hsboard(false),
 m_debug(false),
 m_destinations(),
 m_audioInputDevice(),
@@ -174,6 +175,8 @@ bool CConf::read()
 			else if (::strcmp(key, "Bleep") == 0)
 				m_bleep = ::atoi(value) == 1;
 			else if (::strcmp(key, "Daemon") == 0)
+				m_daemon = ::atoi(value) == 1;
+			else if (::strcmp(key, "Hsboard") == 0)
 				m_daemon = ::atoi(value) == 1;
 			else if (::strcmp(key, "Debug") == 0)
 				m_debug = ::atoi(value) == 1;
@@ -313,6 +316,11 @@ bool CConf::getBleep() const
 bool CConf::getDaemon() const
 {
 	return m_daemon;
+}
+
+bool CConf::getHsboard() const
+{
+	return m_hsboard;
 }
 
 bool CConf::getDebug() const

--- a/Daemon/Conf.h
+++ b/Daemon/Conf.h
@@ -35,6 +35,7 @@ public:
 	std::string  getText() const;
 	bool         getBleep() const;
 	bool         getDaemon() const;
+	bool         getHsboard() const;
 	bool         getDebug() const;
 
 	// The Destinations sections
@@ -110,6 +111,7 @@ private:
 	std::string  m_text;
 	bool         m_bleep;
 	bool         m_daemon;
+	bool		 m_hsboard;
 	bool         m_debug;
 
 	std::vector<std::string> m_destinations;

--- a/Daemon/M17Client.ini
+++ b/Daemon/M17Client.ini
@@ -3,6 +3,7 @@ Callsign=G4KLX
 Text=Jonathan near Crawley / IO91VC
 Bleep=1
 Daemon=0
+HsBoard=0
 Debug=0
 
 [Destinations]
@@ -43,7 +44,7 @@ Debug=0
 # Logging levels, 0=No logging
 DisplayLevel=1
 FileLevel=1
-FilePath=.
+FilePath=/tmp/
 FileRoot=M17Client
 FileRotate=1
 
@@ -56,10 +57,10 @@ TX=0
 TXInvert=0
 RCV=0
 RCVInvert=0
-PTT=15
-PTTInvert=0
-VolumeUp=14
-VolumeDown=13
+PTT=17		#Pin 11
+PTTInvert=0	#Use Pull-Ups for inputs
+VolumeUp=27	#Pin 13
+VolumeDown=22	#Pin 15
 VolumeInvert=0
 
 [HamLib]

--- a/Daemon/Modem.cpp
+++ b/Daemon/Modem.cpp
@@ -400,12 +400,13 @@ bool CModem::open()
 	}
 
 	ret = setFrequency();
-	if (!ret) {
-		m_port->close();
-		delete m_port;
-		m_port = NULL;
-		return false;
-	}
+	if (!ret) {						//Some modem boards do not respond to set frequency command.
+		//m_port->close();
+		//delete m_port;
+		//m_port = NULL;
+		::LogMessage("Unable to set Frequency");
+		//return false;
+	}		
 
 	ret = writeConfig();
 	if (!ret) {


### PR DESCRIPTION
Commented frequency set part that prevents code running with some modem boards.
Changed default log file path to tmp. Now, code can run in readonly filesystem.
Changed default GPIO pins to valid ones.
Added "Hsboard" Hot Spot Board option for future development in ini file. (Currently not used anywhere.)