### PR TITLE
SoundPulse.cpp: use NULL for default device, not pass "default" string

### DIFF
--- a/Daemon/SoundPulse.cpp
+++ b/Daemon/SoundPulse.cpp
@@ -56,13 +56,13 @@ bool CSoundPulse::open()
 	ss.rate = m_sampleRate;
 	ss.channels = 1;
 
-	pa_simple* playHandle = ::pa_simple_new(NULL, "M17Client", PA_STREAM_PLAYBACK, m_writeDevice.c_str(), "Receive", &ss, NULL, NULL, NULL);
+	pa_simple* playHandle = ::pa_simple_new(NULL, "M17Client", PA_STREAM_PLAYBACK, (m_writeDevice == "default") ? NULL : m_writeDevice.c_str(), "Receive", &ss, NULL, NULL, NULL);
 	if (!playHandle) {
 		LogError("Cannot open playback audio device %s", m_writeDevice.c_str());
 		return false;
 	}
 
-	pa_simple* recHandle = ::pa_simple_new(NULL, "M17Client", PA_STREAM_RECORD, m_readDevice.c_str(), "Transmit", &ss, NULL, NULL, NULL);
+	pa_simple* recHandle = ::pa_simple_new(NULL, "M17Client", PA_STREAM_RECORD, (m_readDevice == "default") ? NULL : m_readDevice.c_str(), "Transmit", &ss, NULL, NULL, NULL);
 	if (!recHandle) {
 		LogError("Cannot open capture audio device %s", m_readDevice.c_str());
 		return false;


### PR DESCRIPTION
For default device (sink), dev field of pa_simple_new() requires NULL. Not "default" string.

https://www.freedesktop.org/software/pulseaudio/doxygen/simple_8h.html#add9a7dce4e15955d4296726c26206689

Linux(Debian-12)'s PulseAudio works with "default" string, but others (OpenBSD) not.
Maybe same issue as https://github.com/baresip/baresip/issues/781 .

(off-topic)
ss.format is fixed with PA_SAMPLE_FLOAT32LE. Can this code support for big-endian machine?