### PR TITLE
fix buffer size

### DIFF
--- a/Daemon/SoundALSA.cpp
+++ b/Daemon/SoundALSA.cpp
@@ -207,7 +207,7 @@ m_samples(NULL)
 	assert(channels == 1U || channels == 2U);
 	assert(callback != NULL);
 
-	m_samples = new float[4U * blockSize];
+	m_samples = new float[blockSize];
 }
 
 CSoundALSAReader::~CSoundALSAReader()
@@ -259,7 +259,7 @@ m_samples(NULL)
 	assert(channels == 1U || channels == 2U);
 	assert(callback != NULL);
 
-	m_samples = new float[4U * blockSize];
+	m_samples = new float[2U * blockSize];
 }
 
 CSoundALSAWriter::~CSoundALSAWriter()

--- a/Daemon/SoundPulse.cpp
+++ b/Daemon/SoundPulse.cpp
@@ -120,7 +120,7 @@ m_samples(NULL)
 	assert(channels == 1U || channels == 2U);
 	assert(callback != NULL);
 
-	m_samples = new float[4U * blockSize];
+	m_samples = new float[blockSize];
 }
 
 CSoundPulseReader::~CSoundPulseReader()
@@ -168,7 +168,7 @@ m_samples(NULL)
 	assert(channels == 1U || channels == 2U);
 	assert(callback != NULL);
 
-	m_samples = new float[4U * blockSize];
+	m_samples = new float[2U * blockSize];
 }
 
 CSoundPulseWriter::~CSoundPulseWriter()


### PR DESCRIPTION
CSound{ALSA,Pulse}{Reader,Writer} allocates `float[4U * blockSize]`, but actually uses `float[blockSize]` for reader and `float[2U * blockSize]` for writer respectively.

I thought original code uses `char[4U * blockSize]` and simply changed to float, kept with the number of array.

Is there any significant reason to use `[4U * blocksize]`?
